### PR TITLE
Do not assume packages will have the date updated

### DIFF
--- a/build-hawaii
+++ b/build-hawaii
@@ -1,11 +1,9 @@
 #!/bin/sh
 
-date=$(date +"%Y%m%d")
-
 packages="extra-cmake-modules-git kde-solid-git hawaii-vibe-git hawaii-wallpapers-git hawaii-icon-themes-git hawaii-fluid-themes-git hawaii-fluid-git hawaii-greenisland-git hawaii-shell-git hawaii-shell-weston-plugins-git hawaii-system-preferences-git hawaii-terminal-git hawaii-archiver-git hawaii-eyesight-git sddm-qt5-git"
 
 for pkg in $packages; do
-	file=${pkg}-${date}-1-x86_64.pkg.tar.xz
+	file=${pkg}-*-1-x86_64.pkg.tar.xz
 
 	[ -f ~/chroot/root/repo/${file} ] && continue
 


### PR DESCRIPTION
Pacman 4.1 broke the old behavior.
