### PR TITLE
keep static libraries

### DIFF
--- a/qtdeclarative-git/PKGBUILD
+++ b/qtdeclarative-git/PKGBUILD
@@ -11,7 +11,7 @@ depends=('qtxmlpatterns-git' 'mesa')
 makedepends=('git' 'gdb' 'python2')
 conflicts=('qtjsbackend-git')
 replaces=('qtjsbackend-git')
-options=('!libtool' 'debug')
+options=('!libtool' 'staticlibs' 'debug')
 source=(git://gitorious.org/qt/qtdeclarative.git#branch=stable
         'use-python2.patch')
 md5sums=('SKIP'

--- a/qttools-git/PKGBUILD
+++ b/qttools-git/PKGBUILD
@@ -9,7 +9,7 @@ url="http://qt-project.org/"
 license=('GPL3' 'LGPL')
 depends=('qtbase-git')
 makedepends=('git' 'gdb')
-options=('!libtool' 'debug')
+options=('!libtool' 'staticlibs' 'debug')
 source=(git://gitorious.org/qt/qttools.git#branch=stable)
 md5sums=('SKIP')
 


### PR DESCRIPTION
Arch Linux recently started to strip static libraries from package
builds by default. Since qttools depends on libQt5QmlDevTools.a from
qtdeclarative, add the staticlibs to qtdeclarative to keep this library.

For good measure, add staticlibs to qttools as well. The same is done in
[extra].
