### PR TITLE
enable QtCompositor

### DIFF
--- a/qtwayland-git/PKGBUILD
+++ b/qtwayland-git/PKGBUILD
@@ -24,7 +24,7 @@ prepare() {
 
 build() {
   cd qtwayland
-  /opt/qt-git/bin/qmake
+  /opt/qt-git/bin/qmake CONFIG+=wayland-compositor
   make
 }
 


### PR DESCRIPTION
QtCompositor is not included in the build by default. Hawaii depends on
it, so enable it.
