### PR TITLE
Update PKGBUILD

### DIFF
--- a/qtconfiguration-git/PKGBUILD
+++ b/qtconfiguration-git/PKGBUILD
@@ -28,6 +28,7 @@ prepare() {
 build() {
 	cd build
 	cmake ../${_gitname} \
+		-DCMAKE_INSTALL_LIBDIR=lib \
 		-DCMAKE_INSTALL_PREFIX=/usr \
 		-DCMAKE_BUILD_TYPE=RelWithDebInfo
 }


### PR DESCRIPTION
Without -DCMAKE_INSTALL_LIBDIR=lib the package complains about /usr/lib64 existing in file system (actually a symlink)