### PR TITLE
Update PKGBUILD

### DIFF
--- a/qtaccountsservice-git/PKGBUILD
+++ b/qtaccountsservice-git/PKGBUILD
@@ -30,6 +30,7 @@ prepare() {
 build() {
 	cd build
 	cmake ../${_gitname} \
+		-DCMAKE_INSTALL_LIBDIR=lib \
 		-DCMAKE_INSTALL_PREFIX=/usr \
 		-DCMAKE_BUILD_TYPE=RelWithDebInfo
 }


### PR DESCRIPTION
Package complains about /usr/lib64 existing if this is not added (actually a symlink)
